### PR TITLE
package.json: allow Svelte to compile assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "build": "tsc && rollup --config ./rollup.config.js",
     "serve": "npm run build && webpack serve --content-base public  --config ./.webpack/webpack.dev.js"
   },
+  "svelte": "src/svelte/index.js",
+  "types": "src/index.d.ts",
   "keywords": [
     "spreadsheet",
     "svelte",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "serve": "npm run build && webpack serve --content-base public  --config ./.webpack/webpack.dev.js"
   },
   "svelte": "src/svelte/index.js",
-  "types": "src/index.d.ts",
+  "types": "src/revogrid.ts",
   "keywords": [
     "spreadsheet",
     "svelte",


### PR DESCRIPTION
Also adds support for types.

Fixes issue https://github.com/revolist/svelte-datagrid/issues/4 by allowing project-local Svelte compilers to build the distribution (rather than use pre-compiled distribution).