### PR TITLE
Changing type to Module

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,5 +55,6 @@
   "dependencies": {
     "@revolist/revogrid": "^3.2.15",
     "@stencil/core": "2.17.4"
-  }
+  },
+  "type": "module"
 }


### PR DESCRIPTION
Changing type to Module resolving sveltekit warning:

@revolist/svelte-datagrid doesn't appear to be written in CJS, but also doesn't appear to be a valid ES module
 (i.e. it doesn't have "type": "module" or an .mjs extension for the entry point). 
Please contact the package author to fix.